### PR TITLE
Prepare for 0.2.0 release.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,3 @@
 [workspace]
-members = [
-    "anes",
-    "interactive-test",
-    "fuzzer"
-]
+resolver = "2"
+members = ["anes", "interactive-test", "fuzzer"]

--- a/anes/Cargo.toml
+++ b/anes/Cargo.toml
@@ -28,11 +28,11 @@ default = []
 parser = ["bitflags"]
 
 [dependencies]
-bitflags = { version = "2.2.1", optional = true }
+bitflags = { version = "2.4.1", optional = true }
 
 [dev-dependencies]
-criterion = "0.5"
-libc = "0.2.66"
+criterion = "0.5.1"
+libc = "0.2.150"
 
 [[bench]]
 name = "bench_main"

--- a/anes/Cargo.toml
+++ b/anes/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "anes"
 version = "0.1.6"
-authors = ["Robert Vojta <rvojta@me.com>"]
-edition = "2018"
+authors = [
+  "Robert Vojta <rvojta@me.com>",
+  "Andrew Walbran <qwandor@google.com>",
+]
+edition = "2021"
 description = "ANSI Escape Sequences provider & parser"
-repository = "https://github.com/zrzka/anes-rs"
+repository = "https://github.com/qwandor/anes-rs"
 documentation = "https://docs.rs/anes/"
 license = "MIT OR Apache-2.0"
 keywords = ["terminal", "ansi", "sequence", "code", "parser"]

--- a/anes/Cargo.toml
+++ b/anes/Cargo.toml
@@ -10,6 +10,7 @@ description = "ANSI Escape Sequences provider & parser"
 repository = "https://github.com/qwandor/anes-rs"
 documentation = "https://docs.rs/anes/"
 license = "MIT OR Apache-2.0"
+categories = ["command-line-interface", "parser-implementations"]
 keywords = ["terminal", "ansi", "sequence", "code", "parser"]
 exclude = ["target", "Cargo.lock"]
 readme = "README.md"

--- a/anes/Cargo.toml
+++ b/anes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anes"
-version = "0.1.6"
+version = "0.2.0"
 authors = [
   "Robert Vojta <rvojta@me.com>",
   "Andrew Walbran <qwandor@google.com>",

--- a/fuzzer/Cargo.toml
+++ b/fuzzer/Cargo.toml
@@ -11,5 +11,5 @@ exclude = ["target", "Cargo.lock"]
 publish = false
 
 [dependencies]
-afl = "0.14"
+afl = "0.14.5"
 anes = { path = "../anes", features = ["parser"] }

--- a/interactive-test/Cargo.toml
+++ b/interactive-test/Cargo.toml
@@ -15,4 +15,4 @@ publish = false
 
 [dependencies]
 anes = { path = "../anes" }
-crossterm = "0.27"
+crossterm = "0.27.0"

--- a/interactive-test/Cargo.toml
+++ b/interactive-test/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "interactive-test"
 version = "0.0.1"
-authors = ["Robert Vojta <rvojta@me.com>"]
-edition = "2018"
+authors = [
+  "Robert Vojta <rvojta@me.com>",
+  "Andrew Walbran <qwandor@google.com>",
+]
+edition = "2021"
 description = "Interactive test for the anes."
 repository = "https://github.com/zrzka/anes-rs"
 documentation = "https://docs.rs/anes/"


### PR DESCRIPTION
This release has breaking changes to types such as `KeyModifiers` which use bitflags.